### PR TITLE
build(ci): Fix setting github token on MacOS

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ def tests(session: Session) -> None:
         "pytest-rerunfailures",
         "pytest-xdist",
     )
-    session.run("pytest", env={"GITHUB_TOKEN": os.environ["GITHUB_TOKEN"]}, *args)
+    session.run("pytest", env={"GH_TOKEN": os.environ["GITHUB_TOKEN"]}, *args)
 
 
 @session(python="3.9")


### PR DESCRIPTION
It may be the case that the token must be set with the environment variable name "GH_TOKEN" instead of "GITHUB_TOKEN".