### PR TITLE
build: Allow using Python 3.8.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1785,5 +1785,5 @@ cffi = ["cffi (>=1.11)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8.1,<4"
-content-hash = "9dd3cd9212af4d03b31ed844ee820c752d3170321bca57c78918ab2c2b36f7a1"
+python-versions = "^3.8"
+content-hash = "ff9b77661ad1c23a1be5191593c500c51888c728335bc1d27bc26139c1269d8f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.16.0"
 include = ["CHANGELOG.md"]
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4"
+python = "^3.8"
 click= "^8"
 selectorlib = "~0.16"
 selenium = "^4"
@@ -26,7 +26,7 @@ pytest-httpserver = "^1"
 pytest-random-order = "^1"
 pytest-rerunfailures = "^11"
 pytest-xdist = "^3"
-flake8 = "^6"
+flake8 = {version = "^6", python = ">=3.8.1"}
 mypy = ">=0.931,<=1.1.1"
 flake8-import-order = "^0.18"
 


### PR DESCRIPTION
The tool should work with all Python 3.8 versions, only `flake8` does not.