### PR TITLE
ci: Chrome version is already printed by setup step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,6 @@ jobs:
     - uses: browser-actions/setup-firefox@v1
       with:
         firefox-version: latest
-    - run: chrome --version
     - run: nox --python=${{ matrix.python-version }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sample output from CI:
```
Run browser-actions/setup-chrome@v1
Setup chromium stable
Attempting to download stable...
Acquiring stable from https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
Installing chromium...
/usr/bin/ar x /home/runner/work/_temp/492cc58e-5360-4c78-a026-1d20dcae7e1f
/usr/bin/tar -xf /tmp/deb-fPoyt3/data.tar.xz --directory /tmp/chrome-hzvNNS --strip-components 4 ./opt/google
Successfully Installed chromium to /opt/hostedtoolcache/chromium/stable/x64
Successfully installed chromium to /tmp/chrome-hzvNNS/chrome
/tmp/chrome-hzvNNS/chrome --version
Google Chrome 112.0.5615.121 unknown
Successfully setup chromium version 112.0.5615.121
```

Ref.:
https://github.com/joclement/amarps/actions/runs/4715923399/jobs/8363208388